### PR TITLE
Fixes possible memory leak via buildRelation function

### DIFF
--- a/src/simplePropertyMappers.ts
+++ b/src/simplePropertyMappers.ts
@@ -73,20 +73,15 @@ export function defineRelationGetter(
     relationName,
     buildRelation: TJsonaRelationshipBuild
 ) {
-    let builtRelation;
     Object.defineProperty(
         model,
         relationName,
         {
             enumerable: true,
-            set: (value) => {
-                builtRelation = value;
-            },
+            configurable: true,
             get: () => {
-                if (typeof builtRelation === 'undefined') {
-                    builtRelation = buildRelation();
-                }
-                return builtRelation;
+                delete model[relationName];
+                return model[relationName] = buildRelation();
             },
         },
     );

--- a/tests/Jsona.test.ts
+++ b/tests/Jsona.test.ts
@@ -133,6 +133,23 @@ describe('Jsona', () => {
             expect(model).to.be.deep.equal(circular.model);
         });
 
+        it('should denormalize model with relationships', () => {
+            const model1 = jsona.denormalizeReduxObject({
+                reduxObject: reduxObject1,
+                returnBuilderInRelations: false,
+                entityType: 'town',
+                entityIds: '21'
+            });
+            const model2 = jsona.denormalizeReduxObject({
+                reduxObject: reduxObject1,
+                returnBuilderInRelations: true,
+                entityType: 'town',
+                entityIds: '21'
+            });
+            expect(model1.country).to.be.deep.equal(country1.model);
+            expect(model2.country).to.be.deep.equal(country1.model);
+        });
+
     });
 
 });


### PR DESCRIPTION
1. `buildRelation` is in closure
2. it's binded to `ReduxObjectDenormalizer`
3. instance of `ReduxObjectDenormalizer` has a lot of stuff into `cachedModels`

![2017-11-03 13 16 34](https://user-images.githubusercontent.com/632171/32369164-495d8504-c099-11e7-8590-07532f588660.png)
