### PR TITLE
[Feature] Add `type` attribute to serializer method

### DIFF
--- a/src/Jsona.ts
+++ b/src/Jsona.ts
@@ -40,9 +40,10 @@ class Jsona {
      * Creates JSON, compatible with json:api specification from Jsona model(s).
      */
     serialize(
-        {stuff, includeNames}: {
+        {stuff, includeNames, type}: {
             stuff: TJsonaModel | Array<TJsonaModel>,
-            includeNames?: TJsonaDenormalizedIncludeNames | TJsonaNormalizedIncludeNamesTree
+            includeNames?: TJsonaDenormalizedIncludeNames | TJsonaNormalizedIncludeNamesTree,
+            type?: string
         }
     ): TJsonApiBody {
         if (!stuff) {
@@ -52,6 +53,7 @@ class Jsona {
         const jsonBuilder = new ModelsSerializer(this.modelPropertiesMapper);
 
         jsonBuilder.setStuff(stuff);
+        jsonBuilder.setType(type);
 
         if (includeNames) {
             jsonBuilder.setIncludeNames(includeNames);

--- a/src/builders/ModelsSerializer.ts
+++ b/src/builders/ModelsSerializer.ts
@@ -15,6 +15,7 @@ class ModelsSerializer {
     protected propertiesMapper: IModelPropertiesMapper;
     protected staff: TJsonaModel | Array<TJsonaModel>;
     protected includeNamesTree: TJsonaNormalizedIncludeNamesTree;
+    protected type: string;
 
     constructor(propertiesMapper?: IModelPropertiesMapper) {
         propertiesMapper && this.setPropertiesMapper(propertiesMapper);
@@ -26,6 +27,10 @@ class ModelsSerializer {
 
     setStuff(staff) {
         this.staff = staff;
+    }
+
+    setType(type: string) {
+        this.type = type;
     }
 
     setIncludeNames(includeNames: TJsonaDenormalizedIncludeNames | TJsonaNormalizedIncludeNamesTree) {
@@ -41,7 +46,7 @@ class ModelsSerializer {
     }
 
     build(): TJsonApiBody {
-        const {staff, propertiesMapper} = this;
+        const {staff, propertiesMapper, type} = this;
 
         if (!propertiesMapper || typeof propertiesMapper !== 'object') {
             throw new Error('ModelsSerializer cannot build, propertiesMapper is not set');
@@ -100,6 +105,10 @@ class ModelsSerializer {
             type: this.propertiesMapper.getType(model),
             attributes: this.propertiesMapper.getAttributes(model),
         };
+
+        if (!data.type && this.type) {
+            data.type = this.type
+        }
 
         if (typeof data.type !== 'string' || !data.type) {
             console.warn('ModelsSerializer cannot buildDataByModel, type is not set or incorrect', model);

--- a/tests/Jsona.test.ts
+++ b/tests/Jsona.test.ts
@@ -3,15 +3,15 @@ import {expect} from 'chai';
 import Jsona from '../src';
 
 import {
-    town1,
-    town2,
-    user1,
-    user2,
-    specialty1,
-    specialty2,
-    country1,
-    country2,
-    reduxObject1, circular, reduxObjectWithCircular
+  town1,
+  town2,
+  user1,
+  user2,
+  specialty1,
+  specialty2,
+  country1,
+  country2,
+  reduxObject1, circular, reduxObjectWithCircular, town1WithoutType
 } from './mocks';
 
 chai.config.showDiff = true;
@@ -40,6 +40,11 @@ describe('Jsona', () => {
             expect(jsonBody.data).to.be.deep.equal(user2.json);
             expect(jsonBody.included).to.be.deep.equal([country2.json, specialty1.json, specialty2.json, town2.json]);
         });
+        it('should serialize model without type', () => {
+            const jsonBody = jsona.serialize({stuff: town1WithoutType.model, type: 'town'});
+            expect(jsonBody.data).to.be.deep.equal(town1WithoutType.json);
+            expect(jsonBody.included).to.be.equal(undefined);
+        })
     });
 
     describe('deserialize', () => {

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -55,6 +55,30 @@ export const town1 = {
     }
 };
 
+export const town1WithoutType = {
+  model: {
+    id: '21',
+    name: 'Shanghai',
+    country: country1.model,
+    [RELATIONSHIP_NAMES_PROP]: ['country']
+  },
+  json: {
+    type: 'town',
+    id: '21',
+    attributes: {
+      name: 'Shanghai',
+    },
+    relationships: {
+      country: {
+        data: {
+          type: 'country',
+          id: country1.model.id,
+        }
+      }
+    }
+  }
+};
+
 export const town2 = {
     model: {
         type: 'town',


### PR DESCRIPTION
I suggest to add `type` attribute for `serializer` method – as I'm using this package along with Angular and sending to the server the data which is created by a form. Thus I need every time write something like `myFormValue[‘type’]=‘users’` - this is inconvenient. So I've decided to add this attribute into serializer. 
Below – the simpliest implementation of this. 
Please, check it out and share your thoughts about it. 
Thanks!