### PR TITLE
Fix duplicate model bug

### DIFF
--- a/tests/Jsona.test.ts
+++ b/tests/Jsona.test.ts
@@ -13,6 +13,7 @@ import {
     country2,
     reduxObject1,
     circular,
+    duplicate,
     reduxObjectWithCircular,
     withoutRootIdsMock,
     withNullRelationsMock,
@@ -73,6 +74,11 @@ describe('Jsona', () => {
         it('should deserialize json with circular relationships', () => {
             const recursiveItem = jsona.deserialize(circular.json);
             expect(recursiveItem).to.be.deep.equal(circular.model);
+        });
+
+        it('should deserialize json with duplicate relationships', () => {
+            const duplicateItem = jsona.deserialize(duplicate.json);
+            expect(duplicateItem).to.be.deep.equal(duplicate.model);
         });
 
         it('should deserialize json with data without root ids', () => {

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -353,6 +353,98 @@ export const circular = {
     },
 };
 
+const duplicateModels = [
+    {
+        type: 'model',
+        id: '1',
+        'relationshipNames': [
+            'simpleRelation'
+        ],
+    },
+    {
+        type: 'model',
+        id: '2',
+        'relationshipNames': [
+            'simpleRelation'
+        ],
+    },
+];
+
+const duplicateSubModel = {
+    'type': 'subModel',
+    'id': '1',
+    'relationshipNames': [
+        'simpleRelation2'
+    ],
+};
+
+duplicateModels[0]['simpleRelation'] = duplicateSubModel;
+duplicateModels[1]['simpleRelation'] = duplicateSubModel;
+duplicateSubModel['simpleRelation2'] = [
+  duplicateModels[0],
+  duplicateModels[1],
+];
+
+export const duplicate = {
+    model: duplicateModels,
+    json: {
+        'data': [
+            {
+                'type': 'model',
+                'id': '1',
+                'relationships': {
+                    'simpleRelation': {
+                        'data': {
+                            'type': 'subModel',
+                            'id': '1'
+                        }
+                    },
+                }
+            },
+            {
+                'type': 'model',
+                'id': '2',
+                'relationships': {
+                    'simpleRelation': {
+                        'data': {
+                            'type': 'subModel',
+                            'id': '1'
+                        }
+                    },
+                }
+            }
+        ],
+        'included': [
+            {
+                'type': 'subModel',
+                'id': '1',
+                'relationships': {
+                    'simpleRelation2': {
+                        'data': [
+                            {
+                                'type': 'model',
+                                'id': '1'
+                            },
+                            {
+                                'type': 'model',
+                                'id': '2'
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                'type': 'model',
+                'id': '1',
+            },
+            {
+                'type': 'model',
+                'id': '2',
+            }
+        ]
+    },
+};
+
 export const includeNames1 = {
     denormalized: [
         'articles.author.town.country',
@@ -567,7 +659,12 @@ export const withNullRelationsMock = {
         "slug": "ya",
         "parent": {
             "type": "category",
-            "id": "0"
+            "id": "0",
+            "slug": "home",
+            "parent": null,
+            "relationshipNames": [
+                "parent"
+            ]
         },
         "relationshipNames": [
             "parent"


### PR DESCRIPTION
This pull request fixes a bug where a model is both in the main response
and in the include list. If the model from the include list is seen
first it causes jsona to use that model for the main response as well,
even if it has less properties or relations.

In theory this shouldn't happen but some jsonapi serializers such as the
Go one don't deduplicate models and might include them in both places.

The fix is to first build all main response models and then build the relations. This way the main response models get cached first and the include models that are already in the main response won't get cached instead.

See also: https://github.com/olosegres/jsona/pull/36