### PR TITLE
Fix duplicate model bug

### DIFF
--- a/src/builders/JsonDeserializer.ts
+++ b/src/builders/JsonDeserializer.ts
@@ -51,7 +51,7 @@ class JsonDeserializer implements IJsonaModelBuilder {
 
             for (let i = 0; i < collectionLength; i++) {
                 if (data[i]) {
-                    const model = this.buildModelByData(data[i]);
+                    const model = this.buildModelByData(data[i], true);
 
                     if (model) {
                         stuff.push(model);
@@ -59,17 +59,19 @@ class JsonDeserializer implements IJsonaModelBuilder {
                 }
             }
         } else if (data) {
-            stuff = this.buildModelByData(data);
+            stuff = this.buildModelByData(data, true);
         }
 
         return stuff;
     }
 
-    buildModelByData(data: TJsonApiData): TJsonaModel {
-        const cachedModel = this.dc.getCachedModel(data);
+    buildModelByData(data: TJsonApiData, noCache: boolean = false): TJsonaModel {
+        if (!noCache) {
+            const cachedModel = this.dc.getCachedModel(data);
 
-        if (cachedModel) {
-            return cachedModel;
+            if (cachedModel) {
+                return cachedModel;
+            }
         }
 
         const model = this.pm.createModel(data.type);

--- a/tests/Jsona.test.ts
+++ b/tests/Jsona.test.ts
@@ -13,6 +13,7 @@ import {
     country2,
     reduxObject1,
     circular,
+    duplicate,
     reduxObjectWithCircular,
     withoutRootIdsMock,
     withNullRelationsMock,
@@ -73,6 +74,11 @@ describe('Jsona', () => {
         it('should deserialize json with circular relationships', () => {
             const recursiveItem = jsona.deserialize(circular.json);
             expect(recursiveItem).to.be.deep.equal(circular.model);
+        });
+
+        it('should deserialize json with duplicate relationships', () => {
+            const duplicateItem = jsona.deserialize(duplicate.json);
+            expect(duplicateItem).to.be.deep.equal(duplicate.collection);
         });
 
         it('should deserialize json with data without root ids', () => {

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -353,6 +353,99 @@ export const circular = {
     },
 };
 
+const duplicateModels = [
+     {
+        type: 'model',
+        id: '1',
+        'relationshipNames': [
+            'simpleRelation'
+        ],
+        simpleRelation: {
+            'type': 'subModel',
+            'id': '1',
+            'relationshipNames': [
+                'simpleRelation2'
+            ],
+            simpleRelation2: [
+                {
+                    type: 'model',
+                    id: '2',
+                },
+            ]
+        }
+    },
+    {
+        type: 'model',
+        id: '2',
+        'relationshipNames': [
+            'simpleRelation'
+        ],
+    },
+];
+
+duplicateModels[0]['simpleRelation']['simpleRelation2'].unshift(duplicateModels[0]);
+duplicateModels[1]['simpleRelation'] = duplicateModels[0]['simpleRelation'];
+
+export const duplicate = {
+    collection: duplicateModels,
+    json: {
+        'data': [
+            {
+                'type': 'model',
+                'id': '1',
+                'relationships': {
+                    'simpleRelation': {
+                        'data': {
+                            'type': 'subModel',
+                            'id': '1'
+                        }
+                    },
+                }
+            },
+            {
+                'type': 'model',
+                'id': '2',
+                'relationships': {
+                    'simpleRelation': {
+                        'data': {
+                            'type': 'subModel',
+                            'id': '1'
+                        }
+                    },
+                }
+            }
+        ],
+        'included': [
+            {
+                'type': 'subModel',
+                'id': '1',
+                'relationships': {
+                    'simpleRelation2': {
+                        'data': [
+                            {
+                                'type': 'model',
+                                'id': '1'
+                            },
+                            {
+                                'type': 'model',
+                                'id': '2'
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                'type': 'model',
+                'id': '1',
+            },
+            {
+                'type': 'model',
+                'id': '2',
+            }
+        ]
+    },
+};
+
 export const includeNames1 = {
     denormalized: [
         'articles.author.town.country',


### PR DESCRIPTION
This pull request fixes a bug where a model is both in the main data
and in the include list. If the model from the include list is seen
first it causes jsona to use that model for the main data as well.

Models from the main data shouldn't be fetched from the cache and always
be build correctly.

This is an alternative fix for https://github.com/olosegres/jsona/pull/35

Since the spec doesn't specify what to do with duplicate models we could also handle it this way which results in a different output but is in theory still correct.