### PR TITLE
Make the ModelSerializer and JsonDeserializer parameters to support extension.

### DIFF
--- a/src/Jsona.ts
+++ b/src/Jsona.ts
@@ -1,6 +1,7 @@
 import {
     IModelPropertiesMapper,
     IModelsSerializerConstructor,
+    IJsonDeserializerConstructor,
     IJsonPropertiesMapper,
     TJsonaDenormalizedIncludeNames,
     TJsonaNormalizedIncludeNamesTree,
@@ -29,12 +30,14 @@ class Jsona {
     public jsonPropertiesMapper: IJsonPropertiesMapper = new JsonPropertiesMapper();
     public DeserializeCache: IDeserializeCacheConstructor = DeserializeCache;
     public ModelsSerializer: IModelsSerializerConstructor = ModelsSerializer;
+    public JsonDeserializer: IJsonDeserializerConstructor = JsonDeserializer;
 
     constructor(params?: {
         modelPropertiesMapper?: IModelPropertiesMapper,
         jsonPropertiesMapper?: IJsonPropertiesMapper,
         DeserializeCache?: IDeserializeCacheConstructor,
-        ModelsSerializer?: IModelsSerializerConstructor
+        ModelsSerializer?: IModelsSerializerConstructor,
+        JsonDeserializer?: IJsonDeserializerConstructor
     }) {
         if (params && params.modelPropertiesMapper) {
             this.modelPropertiesMapper = params.modelPropertiesMapper;
@@ -47,6 +50,9 @@ class Jsona {
         }
         if (params && params.ModelsSerializer) {
             this.ModelsSerializer = params.ModelsSerializer;
+        }
+        if (params && params.JsonDeserializer) {
+            this.JsonDeserializer = params.JsonDeserializer;
         }
     }
 
@@ -85,7 +91,7 @@ class Jsona {
         }
 
         const deserializeCache = new this.DeserializeCache();
-        const modelBuilder = new JsonDeserializer(this.jsonPropertiesMapper, deserializeCache, options);
+        const modelBuilder = new this.JsonDeserializer(this.jsonPropertiesMapper, deserializeCache, options);
 
         if (typeof body === 'string') {
             modelBuilder.setJsonParsedObject(jsonParse(body));

--- a/src/Jsona.ts
+++ b/src/Jsona.ts
@@ -1,5 +1,6 @@
 import {
     IModelPropertiesMapper,
+    IModelsSerializerConstructor,
     IJsonPropertiesMapper,
     TJsonaDenormalizedIncludeNames,
     TJsonaNormalizedIncludeNamesTree,
@@ -7,7 +8,7 @@ import {
     TJsonApiBody,
     TReduxObject,
     IDeserializeCacheConstructor,
-    TDeserializeOptions,
+    TDeserializeOptions
 } from './JsonaTypes';
 
 import {jsonParse} from './utils';
@@ -27,11 +28,13 @@ class Jsona {
     public modelPropertiesMapper: IModelPropertiesMapper = new ModelPropertiesMapper();
     public jsonPropertiesMapper: IJsonPropertiesMapper = new JsonPropertiesMapper();
     public DeserializeCache: IDeserializeCacheConstructor = DeserializeCache;
+    public ModelsSerializer: IModelsSerializerConstructor = ModelsSerializer;
 
     constructor(params?: {
         modelPropertiesMapper?: IModelPropertiesMapper,
         jsonPropertiesMapper?: IJsonPropertiesMapper,
         DeserializeCache?: IDeserializeCacheConstructor,
+        ModelsSerializer?: IModelsSerializerConstructor
     }) {
         if (params && params.modelPropertiesMapper) {
             this.modelPropertiesMapper = params.modelPropertiesMapper;
@@ -41,6 +44,9 @@ class Jsona {
         }
         if (params && params.DeserializeCache) {
             this.DeserializeCache = params.DeserializeCache;
+        }
+        if (params && params.ModelsSerializer) {
+            this.ModelsSerializer = params.ModelsSerializer;
         }
     }
 
@@ -58,7 +64,7 @@ class Jsona {
             throw new Error('Jsona can not serialize, stuff is not passed');
         }
 
-        const jsonBuilder = new ModelsSerializer(this.modelPropertiesMapper);
+        const jsonBuilder = new this.ModelsSerializer(this.modelPropertiesMapper);
 
         jsonBuilder.setStuff(stuff);
 

--- a/src/Jsona.ts
+++ b/src/Jsona.ts
@@ -37,7 +37,7 @@ class Jsona {
         jsonPropertiesMapper?: IJsonPropertiesMapper,
         DeserializeCache?: IDeserializeCacheConstructor,
         ModelsSerializer?: IModelsSerializerConstructor,
-        JsonDeserializer?: IJsonDeserializerConstructor
+        JsonDeserializer?: IJsonDeserializerConstructor,
     }) {
         if (params && params.modelPropertiesMapper) {
             this.modelPropertiesMapper = params.modelPropertiesMapper;

--- a/src/JsonaTypes.ts
+++ b/src/JsonaTypes.ts
@@ -31,6 +31,29 @@ export interface IDeserializeCacheConstructor {
     new(): IDeserializeCache;
 }
 
+export interface IModelsSerializer {
+    setPropertiesMapper(propertiesMapper: IModelPropertiesMapper);
+    setStuff(stuff);
+    setIncludeNames(includeNames: TJsonaDenormalizedIncludeNames | TJsonaNormalizedIncludeNamesTree);
+    build(): TJsonApiBody;
+    buildDataByModel(model: TJsonaModel | null): TJsonApiData;
+    buildRelationshipsByModel(model: TJsonaModel);
+    buildIncludedByModel(
+        model: TJsonaModel,
+        includeTree: TJsonaNormalizedIncludeNamesTree,
+        builtIncluded: TJsonaUniqueIncluded
+    ): void;
+    buildIncludedItem(
+        relationModel: TJsonaModel,
+        subIncludeTree: TJsonaNormalizedIncludeNamesTree,
+        builtIncluded: TJsonaUniqueIncluded
+    );
+}
+
+export interface IModelsSerializerConstructor {
+    new(propertiesMapper?: IModelPropertiesMapper);
+}
+
 export type TDeserializeOptions = {
     preferNestedDataFromData?: boolean,
 }

--- a/src/JsonaTypes.ts
+++ b/src/JsonaTypes.ts
@@ -31,6 +31,21 @@ export interface IDeserializeCacheConstructor {
     new(): IDeserializeCache;
 }
 
+export interface IJsonaDeserializer extends IJsonaModelBuilder {
+    setDeserializeCache(dc: IDeserializeCache): void;
+    setPropertiesMapper(pm: IJsonPropertiesMapper): void;
+    setJsonParsedObject(body: TJsonApiBody): void;
+    buildModelByData(data: TJsonApiData): TJsonaModel;
+    buildRelationsByData(data: TJsonApiData, model: TJsonaModel): TJsonaRelationships | null;
+    buildDataFromIncludedOrData(id: string | number, type: string): TJsonApiData;
+    buildDataInObject(): { [key: string]: TJsonApiData };
+    buildIncludedInObject(): { [key: string]: TJsonApiData };
+}
+
+export interface IJsonDeserializerConstructor {
+    new(propertiesMapper: IJsonPropertiesMapper, deserializeCache: IDeserializeCache, options);
+}
+
 export interface IModelsSerializer {
     setPropertiesMapper(propertiesMapper: IModelPropertiesMapper);
     setStuff(stuff);

--- a/src/JsonaTypes.ts
+++ b/src/JsonaTypes.ts
@@ -51,7 +51,7 @@ export interface IModelsSerializer {
 }
 
 export interface IModelsSerializerConstructor {
-    new(propertiesMapper?: IModelPropertiesMapper);
+    new(propertiesMapper?: IModelPropertiesMapper): IModelsSerializer;
 }
 
 export type TDeserializeOptions = {

--- a/src/builders/JsonDeserializer.ts
+++ b/src/builders/JsonDeserializer.ts
@@ -4,11 +4,11 @@ import {
     TJsonaRelationships,
     TJsonApiBody,
     TJsonApiData,
-    IJsonaModelBuilder,
+    IJsonaDeserializer,
     IDeserializeCache,
 } from '../JsonaTypes';
 
-class JsonDeserializer implements IJsonaModelBuilder {
+class JsonDeserializer implements IJsonaDeserializer {
 
     protected pm: IJsonPropertiesMapper;
     protected dc: IDeserializeCache;

--- a/src/builders/JsonDeserializer.ts
+++ b/src/builders/JsonDeserializer.ts
@@ -8,7 +8,7 @@ import {
     IDeserializeCache,
 } from '../JsonaTypes';
 
-class JsonDeserializer implements IJsonaDeserializer {
+export class JsonDeserializer implements IJsonaDeserializer {
 
     protected pm: IJsonPropertiesMapper;
     protected dc: IDeserializeCache;

--- a/src/builders/ModelsSerializer.ts
+++ b/src/builders/ModelsSerializer.ts
@@ -5,12 +5,13 @@ import {
     TJsonaDenormalizedIncludeNames,
     TJsonaNormalizedIncludeNamesTree,
     TJsonaUniqueIncluded,
-    IModelPropertiesMapper
+    IModelPropertiesMapper,
+    IModelsSerializer
 } from '../JsonaTypes';
 
 import {createIncludeNamesTree} from '../utils';
 
-class ModelsSerializer {
+export class ModelsSerializer implements IModelsSerializer {
 
     protected propertiesMapper: IModelPropertiesMapper;
     protected stuff: TJsonaModel | Array<TJsonaModel>;


### PR DESCRIPTION
As detailed in https://github.com/olosegres/jsona/issues/32#issuecomment-531159183, there are scenarios where the `ModelSerializer` and `JsonDeserializer` being extensible are beneficial. This pull supports this behavior.