### PR TITLE
Avoid require cycle

### DIFF
--- a/src/switchCasePropertyMappers.ts
+++ b/src/switchCasePropertyMappers.ts
@@ -6,7 +6,7 @@ import {
     SwitchCaseModelMapperOptionsType,
     SwitchCaseJsonMapperOptionsType,
 } from './JsonaTypes';
-import {ModelPropertiesMapper, JsonPropertiesMapper} from './';
+import {ModelPropertiesMapper, JsonPropertiesMapper} from './simplePropertyMappers';
 import {RELATIONSHIP_NAMES_PROP} from "./simplePropertyMappers";
 
 export class SwitchCaseModelMapper extends ModelPropertiesMapper implements IModelPropertiesMapper {


### PR DESCRIPTION
The require cycle was caused by
The index.ts require src/switchCasePropertyMappers.ts
and
and the src/switchCasePropertyMappers.ts require index.ts 