### PR TITLE
Combined same imports source

### DIFF
--- a/src/switchCasePropertyMappers.ts
+++ b/src/switchCasePropertyMappers.ts
@@ -6,8 +6,11 @@ import {
     SwitchCaseModelMapperOptionsType,
     SwitchCaseJsonMapperOptionsType,
 } from './JsonaTypes';
-import {ModelPropertiesMapper, JsonPropertiesMapper} from './simplePropertyMappers';
-import {RELATIONSHIP_NAMES_PROP} from "./simplePropertyMappers";
+import {
+    ModelPropertiesMapper, 
+    JsonPropertiesMapper,
+    RELATIONSHIP_NAMES_PROP,
+} from './simplePropertyMappers';
 
 export class SwitchCaseModelMapper extends ModelPropertiesMapper implements IModelPropertiesMapper {
 


### PR DESCRIPTION
There are two imports from ./simplePropertyMappers in src/switchCasePropertyMappers.ts which was caused by my last PR.