### PR TITLE
nullable relation data type

### DIFF
--- a/src/JsonaTypes.ts
+++ b/src/JsonaTypes.ts
@@ -1,4 +1,6 @@
 
+type AtLeastOneProperty<T, U = {[K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U];
+
 export interface IModelPropertiesMapper {
     getId(model: TJsonaModel): string | number;
     getType(model: TJsonaModel): string;
@@ -98,11 +100,13 @@ export type TJsonApiRelationshipData = {
     meta?: TAnyKeyValueObject
 };
 
-export type TJsonApiRelation = {
-    data: TJsonApiRelationshipData | Array<TJsonApiRelationshipData> | null
-    links?: TJsonApiLinks
-    meta?: TAnyKeyValueObject
-};
+type FullTJsonApiRelation = {
+    data: TJsonApiRelationshipData | Array<TJsonApiRelationshipData>
+    links: TJsonApiLinks
+    meta: TAnyKeyValueObject
+}
+
+export type TJsonApiRelation = AtLeastOneProperty<FullTJsonApiRelation>;
 
 export type TJsonApiLinks = {
     self: string,

--- a/src/JsonaTypes.ts
+++ b/src/JsonaTypes.ts
@@ -99,7 +99,7 @@ export type TJsonApiRelationshipData = {
 };
 
 export type TJsonApiRelation = {
-    data: TJsonApiRelationshipData | Array<TJsonApiRelationshipData>
+    data: TJsonApiRelationshipData | Array<TJsonApiRelationshipData> | null
     links?: TJsonApiLinks
     meta?: TAnyKeyValueObject
 };


### PR DESCRIPTION
The code is handling nullable relationship data, but the `null` type  for `TJsonApiRelation.data` is missing.