### PR TITLE
Add properties to TJsonApiLinks as required by the pagination spec

### DIFF
--- a/src/JsonaTypes.ts
+++ b/src/JsonaTypes.ts
@@ -110,7 +110,11 @@ export type TJsonApiRelation = AtLeastOneProperty<FullTJsonApiRelation>;
 
 export type TJsonApiLinks = {
     self: string,
-    related: string
+    related: string,
+    first?: string | null,
+    last?: string | null,
+    prev?: string | null,
+    next?: string | null,
 };
 
 export type TJsonApiRelationships = {


### PR DESCRIPTION
Adds proper types for pagination to `TJsonApiLinks` type.
Willing to add tests but would need a bit of help setting up mock data.
closes #47