### PR TITLE
Update TJsonApiLinks to spec

### DIFF
--- a/src/JsonaTypes.ts
+++ b/src/JsonaTypes.ts
@@ -1,4 +1,3 @@
-
 type AtLeastOneProperty<T, U = {[K in keyof T]: Pick<T, K> }> = Partial<T> & U[keyof U];
 
 export interface IModelPropertiesMapper {
@@ -108,13 +107,13 @@ type FullTJsonApiRelation = {
 
 export type TJsonApiRelation = AtLeastOneProperty<FullTJsonApiRelation>;
 
+type LinkKey = "self" | "related" | "first" | "prev" | "next" | "last";
+
+// https://jsonapi.org/format/#document-links
+type LinkObjectMember = string | { href?: string; meta?: TAnyKeyValueObject } | null;
+
 export type TJsonApiLinks = {
-    self: string,
-    related: string,
-    first?: string | null,
-    last?: string | null,
-    prev?: string | null,
-    next?: string | null,
+  [key in LinkKey]?: LinkObjectMember;
 };
 
 export type TJsonApiRelationships = {


### PR DESCRIPTION
Hello. I recently submitted a PR that updated `TJsonApiLinks`. I have recently noticed that type is not actually to spec, as the `links` property can contain an object with `href` and or `meta` properties.

see https://jsonapi.org/format/#document-links

I have updated the `TJsonApiLinks` type to reflect this.